### PR TITLE
feat(planning_msgs): add occlusion spot slow down as stop reason

### DIFF
--- a/tier4_planning_msgs/msg/StopReason.msg
+++ b/tier4_planning_msgs/msg/StopReason.msg
@@ -13,6 +13,7 @@ string BLOCKED_BY_OBSTACLE=BlockedByObstacle
 string STOPPING_LANE_CHANGE=StoppingLaneChange
 string REMOTE_EMERGENCY_STOP=RemoteEmergencyStop
 string VIRTUAL_TRAFFIC_LIGHT=VirtualTrafficLight
+string OCCLUSION_SPOT_SLOWDOWN=OcclusionSpotSlowDown
 string reason
 
 tier4_planning_msgs/StopFactor[] stop_factors


### PR DESCRIPTION
## Related Links

adding occlusion spot slowdown as stop reason to identify behavior velocity planner 's decision like other scene modules. 

## Description

adding occlusion spot slow down reason

## Remarks

occlusion spot module doesn't insert stop velocity but it can insert almost zero velocity.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
