### PR TITLE
feat(tier4_localization_msgs): remove pose initialization request 

### DIFF
--- a/tier4_localization_msgs/CMakeLists.txt
+++ b/tier4_localization_msgs/CMakeLists.txt
@@ -15,7 +15,6 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
-  "msg/PoseInitializationRequest.msg"
   "srv/PoseWithCovarianceStamped.srv"
   DEPENDENCIES
     builtin_interfaces

--- a/tier4_localization_msgs/msg/PoseInitializationRequest.msg
+++ b/tier4_localization_msgs/msg/PoseInitializationRequest.msg
@@ -1,2 +1,0 @@
-builtin_interfaces/Time stamp
-bool data

--- a/tier4_localization_msgs/srv/PoseWithCovarianceStamped.srv
+++ b/tier4_localization_msgs/srv/PoseWithCovarianceStamped.srv
@@ -1,7 +1,4 @@
-# A sequence number is included to do primitive error checking
-uint32 seq
 geometry_msgs/PoseWithCovarianceStamped pose_with_covariance
 ---
 bool success
-uint32 seq
 geometry_msgs/PoseWithCovarianceStamped pose_with_covariance


### PR DESCRIPTION
## Related Links

For this PR.
https://github.com/autowarefoundation/autoware.universe/pull/1500

## Description

- Remove the unused service `PoseInitializationRequest`.
- Remove the unused field `seq` in `PoseWithCovarianceStamped`. 

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
