### PR TITLE
refactor!: remove tier4 control mode msg

### DIFF
--- a/tier4_auto_msgs_converter/include/tier4_auto_msgs_converter/tier4_auto_msgs_converter.hpp
+++ b/tier4_auto_msgs_converter/include/tier4_auto_msgs_converter/tier4_auto_msgs_converter.hpp
@@ -35,7 +35,6 @@
 #include "tier4_planning_msgs/msg/trajectory.hpp"
 #include "tier4_system_msgs/msg/autoware_state.hpp"
 #include "tier4_system_msgs/msg/hazard_status_stamped.hpp"
-#include "tier4_vehicle_msgs/msg/control_mode.hpp"
 #include "tier4_vehicle_msgs/msg/shift_stamped.hpp"
 #include "tier4_vehicle_msgs/msg/steering.hpp"
 #include "tier4_vehicle_msgs/msg/turn_signal.hpp"
@@ -124,24 +123,6 @@ inline auto convert(const autoware_auto_planning_msgs::msg::Trajectory & traj)
     iv_traj.points.push_back(iv_point);
   }
   return iv_traj;
-}
-
-inline auto convert(const autoware_auto_vehicle_msgs::msg::ControlModeReport & mode)
-{
-  tier4_vehicle_msgs::msg::ControlMode iv_mode;
-  iv_mode.header.stamp = mode.stamp;
-  switch (mode.mode) {
-    case autoware_auto_vehicle_msgs::msg::ControlModeReport::MANUAL:
-      iv_mode.data = tier4_vehicle_msgs::msg::ControlMode::MANUAL;
-      break;
-    case autoware_auto_vehicle_msgs::msg::ControlModeReport::AUTONOMOUS:
-      iv_mode.data = tier4_vehicle_msgs::msg::ControlMode::AUTO;
-      break;
-    default:
-      iv_mode.data = tier4_vehicle_msgs::msg::ControlMode::MANUAL;
-      break;
-  }
-  return iv_mode;
 }
 
 inline auto convert(const autoware_auto_vehicle_msgs::msg::GearReport & gear)

--- a/tier4_vehicle_msgs/CMakeLists.txt
+++ b/tier4_vehicle_msgs/CMakeLists.txt
@@ -20,12 +20,10 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/BatteryStatus.msg"
   "msg/Shift.msg"
   "msg/ShiftStamped.msg"
-  "msg/ControlMode.msg"
   "msg/TurnSignal.msg"
   "msg/Steering.msg"
   "msg/SteeringWheelStatusStamped.msg"
   "msg/VehicleEmergencyStamped.msg"
-  "srv/ControlModeRequest.srv"
   "srv/UpdateAccelBrakeMap.srv"
   DEPENDENCIES std_msgs geometry_msgs tier4_control_msgs
 )

--- a/tier4_vehicle_msgs/msg/ControlMode.msg
+++ b/tier4_vehicle_msgs/msg/ControlMode.msg
@@ -1,7 +1,0 @@
-std_msgs/Header header
-uint8 MANUAL = 0
-uint8 AUTO = 1
-uint8 AUTO_STEER_ONLY = 2
-uint8 AUTO_PEDAL_ONLY = 3
-
-int32 data

--- a/tier4_vehicle_msgs/srv/ControlModeRequest.srv
+++ b/tier4_vehicle_msgs/srv/ControlModeRequest.srv
@@ -1,3 +1,0 @@
-ControlMode mode
----
-bool success


### PR DESCRIPTION
## Description

- Remove `ControlMode` messages to solve duplicates with autoware_auto_msgs's controlMode.
- 
See https://github.com/autowarefoundation/autoware.universe/issues/1509 for the background.
## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute

For T4 issue tracking: https://tier4.atlassian.net/browse/T4PB-18987