### PR TITLE
build: remove unused `<depend>` in package.xml files

### DIFF
--- a/tier4_auto_msgs_converter/package.xml
+++ b/tier4_auto_msgs_converter/package.xml
@@ -13,6 +13,7 @@
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>tier4_external_api_msgs</depend>
   <depend>tier4_perception_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>tier4_system_msgs</depend>

--- a/tier4_control_msgs/CMakeLists.txt
+++ b/tier4_control_msgs/CMakeLists.txt
@@ -23,7 +23,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/SetPause.srv"
   DEPENDENCIES
     autoware_common_msgs
-    std_msgs
+    builtin_interfaces
 )
 
 if(BUILD_TESTING)

--- a/tier4_control_msgs/package.xml
+++ b/tier4_control_msgs/package.xml
@@ -12,7 +12,7 @@
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>autoware_common_msgs</depend>
-  <depend>std_msgs</depend>
+  <depend>builtin_interfaces</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/tier4_localization_msgs/package.xml
+++ b/tier4_localization_msgs/package.xml
@@ -11,7 +11,6 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
-  <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/tier4_perception_msgs/package.xml
+++ b/tier4_perception_msgs/package.xml
@@ -12,7 +12,6 @@
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
-  <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>

--- a/tier4_planning_msgs/CMakeLists.txt
+++ b/tier4_planning_msgs/CMakeLists.txt
@@ -46,7 +46,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
     geometry_msgs
     nav_msgs
     std_msgs
-    unique_identifier_msgs
 )
 
 if(BUILD_TESTING)

--- a/tier4_planning_msgs/package.xml
+++ b/tier4_planning_msgs/package.xml
@@ -15,7 +15,6 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>unique_identifier_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/tier4_simulation_msgs/CMakeLists.txt
+++ b/tier4_simulation_msgs/CMakeLists.txt
@@ -20,7 +20,9 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/SimulationEvents.msg
   msg/UserDefinedValue.msg
   msg/UserDefinedValueType.msg
-  DEPENDENCIES builtin_interfaces std_msgs)
+  DEPENDENCIES 
+    builtin_interfaces
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/tier4_simulation_msgs/CMakeLists.txt
+++ b/tier4_simulation_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/SimulationEvents.msg
   msg/UserDefinedValue.msg
   msg/UserDefinedValueType.msg
-  DEPENDENCIES 
+  DEPENDENCIES
     builtin_interfaces
 )
 

--- a/tier4_simulation_msgs/package.xml
+++ b/tier4_simulation_msgs/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
-  <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/tier4_v2x_msgs/CMakeLists.txt
+++ b/tier4_v2x_msgs/CMakeLists.txt
@@ -21,7 +21,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/VirtualTrafficLightState.msg"
   "msg/VirtualTrafficLightStateArray.msg"
   DEPENDENCIES
-    std_msgs
+    builtin_interfaces
 )
 
 if(BUILD_TESTING)

--- a/tier4_v2x_msgs/package.xml
+++ b/tier4_v2x_msgs/package.xml
@@ -12,7 +12,6 @@
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>builtin_interfaces</depend>
-  <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/tier4_vehicle_msgs/CMakeLists.txt
+++ b/tier4_vehicle_msgs/CMakeLists.txt
@@ -25,7 +25,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/SteeringWheelStatusStamped.msg"
   "msg/VehicleEmergencyStamped.msg"
   "srv/UpdateAccelBrakeMap.srv"
-  DEPENDENCIES std_msgs geometry_msgs tier4_control_msgs
+  DEPENDENCIES 
+    std_msgs
 )
 
 if(BUILD_TESTING)

--- a/tier4_vehicle_msgs/CMakeLists.txt
+++ b/tier4_vehicle_msgs/CMakeLists.txt
@@ -25,7 +25,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/SteeringWheelStatusStamped.msg"
   "msg/VehicleEmergencyStamped.msg"
   "srv/UpdateAccelBrakeMap.srv"
-  DEPENDENCIES 
+  DEPENDENCIES
     std_msgs
 )
 

--- a/tier4_vehicle_msgs/package.xml
+++ b/tier4_vehicle_msgs/package.xml
@@ -11,9 +11,7 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
-  <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>tier4_control_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
See https://github.com/autowarefoundation/autoware/issues/3468
To be merged after https://github.com/autowarefoundation/autoware.universe/pull/3606 to avoid missing deps.

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

<!-- Describe what this PR changes. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
