### PR TITLE
feat(tier4_perception_msgs): add traffic light msgs

### DIFF
--- a/tier4_perception_msgs/CMakeLists.txt
+++ b/tier4_perception_msgs/CMakeLists.txt
@@ -24,6 +24,11 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/object_recognition/Semantic.msg"
   "msg/object_recognition/Shape.msg"
   "msg/object_recognition/State.msg"
+  "msg/traffic_light/TrafficLightElement.msg"
+  "msg/traffic_light/TrafficLightRoi.msg"
+  "msg/traffic_light/TrafficLightRoiArray.msg"
+  "msg/traffic_light/TrafficSignal.msg"
+  "msg/traffic_light/TrafficSignalArray.msg"
   DEPENDENCIES
     autoware_auto_perception_msgs
     builtin_interfaces

--- a/tier4_perception_msgs/msg/traffic_light/TrafficLightElement.msg
+++ b/tier4_perception_msgs/msg/traffic_light/TrafficLightElement.msg
@@ -1,0 +1,23 @@
+uint8 RED=1
+uint8 AMBER=2
+uint8 GREEN=3
+uint8 WHITE=4
+uint8 CIRCLE=5
+uint8 LEFT_ARROW=6
+uint8 RIGHT_ARROW=7
+uint8 UP_ARROW=8
+uint8 UP_LEFT_ARROW=9
+uint8 UP_RIGHT_ARROW=10
+uint8 DOWN_ARROW=11
+uint8 DOWN_LEFT_ARROW=12
+uint8 DOWN_RIGHT_ARROW=13
+uint8 CROSS=14
+uint8 SOLID_OFF=15
+uint8 SOLID_ON=16
+uint8 FLASHING=17
+uint8 UNKNOWN=18
+
+uint8 color
+uint8 shape
+uint8 status
+float64 confidence

--- a/tier4_perception_msgs/msg/traffic_light/TrafficLightRoi.msg
+++ b/tier4_perception_msgs/msg/traffic_light/TrafficLightRoi.msg
@@ -1,0 +1,2 @@
+sensor_msgs/RegionOfInterest roi
+int64 traffic_light_id

--- a/tier4_perception_msgs/msg/traffic_light/TrafficLightRoiArray.msg
+++ b/tier4_perception_msgs/msg/traffic_light/TrafficLightRoiArray.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+tier4_perception_msgs/TrafficLightRoi[] rois

--- a/tier4_perception_msgs/msg/traffic_light/TrafficSignal.msg
+++ b/tier4_perception_msgs/msg/traffic_light/TrafficSignal.msg
@@ -1,0 +1,2 @@
+int64 traffic_light_id
+tier4_perception_msgs/TrafficLightElement[] elements

--- a/tier4_perception_msgs/msg/traffic_light/TrafficSignalArray.msg
+++ b/tier4_perception_msgs/msg/traffic_light/TrafficSignalArray.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+tier4_perception_msgs/TrafficSignal[] signals


### PR DESCRIPTION
This PR creates tier4 perception msgs for traffic lights, as decided [here](https://star4.slack.com/archives/C03S84LDJGG/p1687834314734209?thread_ts=1687833925.646399&cid=C03S84LDJGG)

related to https://github.com/autowarefoundation/autoware.universe/pull/4084, https://github.com/autowarefoundation/autoware.universe/pull/4050