### PR TITLE
feat(tier4_perception_msgs): add traffic_light_type to msg

### DIFF
--- a/tier4_perception_msgs/msg/traffic_light/TrafficLightRoi.msg
+++ b/tier4_perception_msgs/msg/traffic_light/TrafficLightRoi.msg
@@ -1,2 +1,7 @@
+
+uint8 CAR_TL=0
+uint8 PEDESTRIAN_TL=1
+
 sensor_msgs/RegionOfInterest roi
 int64 traffic_light_id
+uint8 traffic_light_type

--- a/tier4_perception_msgs/msg/traffic_light/TrafficLightRoi.msg
+++ b/tier4_perception_msgs/msg/traffic_light/TrafficLightRoi.msg
@@ -1,4 +1,3 @@
-
 uint8 CAR_TL=0
 uint8 PEDESTRIAN_TL=1
 

--- a/tier4_perception_msgs/msg/traffic_light/TrafficLightRoi.msg
+++ b/tier4_perception_msgs/msg/traffic_light/TrafficLightRoi.msg
@@ -1,5 +1,5 @@
-uint8 CAR_TL=0
-uint8 PEDESTRIAN_TL=1
+uint8 CAR_TRAFFIC_LIGHT=0
+uint8 PEDESTRIAN_TRAFFIC_LIGHT=1
 
 sensor_msgs/RegionOfInterest roi
 int64 traffic_light_id

--- a/tier4_perception_msgs/msg/traffic_light/TrafficSignal.msg
+++ b/tier4_perception_msgs/msg/traffic_light/TrafficSignal.msg
@@ -1,5 +1,5 @@
-uint8 CAR_TL=0
-uint8 PEDESTRIAN_TL=1
+uint8 CAR_TRAFFIC_LIGHT=0
+uint8 PEDESTRIAN_TRAFFIC_LIGHT=1
 
 int64 traffic_light_id
 uint8 traffic_light_type

--- a/tier4_perception_msgs/msg/traffic_light/TrafficSignal.msg
+++ b/tier4_perception_msgs/msg/traffic_light/TrafficSignal.msg
@@ -1,2 +1,6 @@
+uint8 CAR_TL=0
+uint8 PEDESTRIAN_TL=1
+
 int64 traffic_light_id
+uint8 traffic_light_type
 tier4_perception_msgs/TrafficLightElement[] elements


### PR DESCRIPTION
## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

This pull request add traffic_light_type attribute to the TrafficLightRoi.msg and TrafficSignal.msg, in order to distinguish traffic lights that are for pedestrians from that are for cars. 
These messages are mainly used for traffic light recognition.

## Related PR
https://github.com/autowarefoundation/autoware.universe/pull/5871

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code is properly formatted
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
