### PR TITLE
feat(tier4_planning_msgs): add internal route interface

### DIFF
--- a/tier4_planning_msgs/CMakeLists.txt
+++ b/tier4_planning_msgs/CMakeLists.txt
@@ -33,6 +33,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/PathChangeModuleId.msg"
   "msg/PathPoint.msg"
   "msg/RerouteAvailability.msg"
+  "msg/RouteState.msg"
   "msg/Scenario.msg"
   "msg/StopFactor.msg"
   "msg/StopReason.msg"
@@ -43,7 +44,13 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/VelocityLimit.msg"
   "msg/VelocityLimitClearCommand.msg"
   "msg/VelocityLimitConstraints.msg"
+  "srv/ClearRoute.srv"
+  "srv/SetLaneletRoute.srv"
+  "srv/SetWaypointRoute.srv"
   DEPENDENCIES
+    autoware_common_msgs
+    autoware_planning_msgs
+    builtin_interfaces
     geometry_msgs
     nav_msgs
     std_msgs

--- a/tier4_planning_msgs/msg/RouteState.msg
+++ b/tier4_planning_msgs/msg/RouteState.msg
@@ -1,0 +1,11 @@
+uint8 UNKNOWN = 0
+uint8 INITIALIZING = 1
+uint8 UNSET = 2
+uint8 ROUTING = 3
+uint8 SET = 4
+uint8 REROUTING = 5
+uint8 ARRIVED = 6
+uint8 ABORTED = 7
+
+builtin_interfaces/Time stamp
+uint8 state

--- a/tier4_planning_msgs/msg/RouteState.msg
+++ b/tier4_planning_msgs/msg/RouteState.msg
@@ -6,6 +6,7 @@ uint8 SET = 4
 uint8 REROUTING = 5
 uint8 ARRIVED = 6
 uint8 ABORTED = 7
+uint8 INTERRUPTED = 8
 
 builtin_interfaces/Time stamp
 uint8 state

--- a/tier4_planning_msgs/package.xml
+++ b/tier4_planning_msgs/package.xml
@@ -11,6 +11,8 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
+  <depend>autoware_common_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/tier4_planning_msgs/srv/ClearRoute.srv
+++ b/tier4_planning_msgs/srv/ClearRoute.srv
@@ -1,0 +1,2 @@
+---
+autoware_common_msgs/ResponseStatus status

--- a/tier4_planning_msgs/srv/SetLaneletRoute.srv
+++ b/tier4_planning_msgs/srv/SetLaneletRoute.srv
@@ -1,0 +1,7 @@
+std_msgs/Header header
+geometry_msgs/Pose goal_pose
+autoware_planning_msgs/LaneletSegment[] segments
+unique_identifier_msgs/UUID uuid
+bool allow_modification
+---
+autoware_common_msgs/ResponseStatus status

--- a/tier4_planning_msgs/srv/SetWaypointRoute.srv
+++ b/tier4_planning_msgs/srv/SetWaypointRoute.srv
@@ -1,0 +1,7 @@
+std_msgs/Header header
+geometry_msgs/Pose goal_pose
+geometry_msgs/Pose[] waypoints
+unique_identifier_msgs/UUID uuid
+bool allow_modification
+---
+autoware_common_msgs/ResponseStatus status


### PR DESCRIPTION
## Related Links

https://github.com/autowarefoundation/autoware.universe/issues/6319

## Description

Add internal route messages/services for https://github.com/autowarefoundation/autoware.universe/issues/6319.
- `SetLanaletRoute` is almost the same as ADAPI `SetRoute` with the addition of a UUID.
- `SetWaypointsRoute` is almost the same as ADAPI `SetRoutePoints` with the addition of a UUID.
- `ClearRoute` is the same as ADAPI, but I copied it so that it is in the same package as the other services.
- `RouteState` is based on the ADAPI, with additional intermediate states used for communication between nodes.

## Remarks

None

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
