### PR TITLE
feat(tier4_system_msgs): add emergency holding msg

### DIFF
--- a/tier4_system_msgs/CMakeLists.txt
+++ b/tier4_system_msgs/CMakeLists.txt
@@ -30,6 +30,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/OperationModeAvailability.msg"
   "msg/EmergencyGoalsClearCommand.msg"
   "msg/EmergencyGoalsStamped.msg"
+  "msg/EmergencyHoldingState.msg"
   "msg/EmergencyState.msg"
   "msg/EmergencyStateStamped.msg"
   "msg/HazardStatus.msg"

--- a/tier4_system_msgs/msg/EmergencyHoldingState.msg
+++ b/tier4_system_msgs/msg/EmergencyHoldingState.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+bool state

--- a/tier4_system_msgs/msg/EmergencyHoldingState.msg
+++ b/tier4_system_msgs/msg/EmergencyHoldingState.msg
@@ -1,2 +1,3 @@
+# This message will be deprecated once hazard_status_converter and hazard_status are deprecated. 
 builtin_interfaces/Time stamp
 bool is_holding

--- a/tier4_system_msgs/msg/EmergencyHoldingState.msg
+++ b/tier4_system_msgs/msg/EmergencyHoldingState.msg
@@ -1,2 +1,2 @@
 builtin_interfaces/Time stamp
-bool state
+bool is_holding

--- a/tier4_system_msgs/msg/EmergencyHoldingState.msg
+++ b/tier4_system_msgs/msg/EmergencyHoldingState.msg
@@ -1,3 +1,3 @@
-# This message will be deprecated once hazard_status_converter and hazard_status are deprecated. 
+# This message will be deprecated once hazard_status_converter and hazard_status are deprecated.
 builtin_interfaces/Time stamp
 bool is_holding


### PR DESCRIPTION
## Related Links

**Purpose of the message**
<!-- Please write related links to GitHub/Jira/Slack/etc. -->

https://star4.slack.com/archives/C017VB9UG1L/p1729675438504999

↑Details of this chat

Currently, on X1, there is an issue where Autoware is in an Emergency state, but an Error notification is not displayed on the FMS. The condition for displaying an Error on the FMS is that the `emergency_holding` value within the `hazard_status` topic is set to true.

This issue is caused by the fact that when the configuration of `system_error_monitor and emergency_handler` was changed to the configuration of `diagnostic_graph_aggregator, mrm_handler, and hazard_status_converter`([discussion](https://github.com/orgs/autowarefoundation/discussions/4176)), the implementation of `hazard_status_converter` was set so that the `emergency_holding` value in the published `hazard_status` topic is always `false`.

The emergency_holding function, which previously existed in the `system_error_monitor`, has now been moved to the `mrm_handler`. Therefore, to update the `emergency_holding` value in the `hazard_status` topic published by the `hazard_status_converter`, it is necessary to transmit the emergency_holding state from the `mrm_handler`. This is why the current PR is required to address the issue.


**Which node is meant to publish/subscribe the topic?**

 Pub: mrm_handler（[PR](https://github.com/autowarefoundation/autoware.universe/pull/9285)）
 Sub: hazard_status_converter（[PR](https://github.com/autowarefoundation/autoware.universe/pull/9287)）
 


 **Does this message has to be in a separate message?**

 This message is temporary. In the future, both `hazard_status_converter and hazard_status` will be deprecated, and `hazard_status` will no longer be used as an API. However, due to the aforementioned issue, a temporary topic addition will be made.

Currently, there is a topic called `/system/operation_mode/availability` from `mrm_handler` to `hazard_status_converter`, but adding the `emergency_holding` state to this topic would be inappropriate given its intended content. Since this is only a temporary value until `hazard_status_converter` is deprecated, the topic should be created independently.


## Description

<!-- Describe what this PR changes. -->
This PR adds EmergencyHodingState msg.

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
