### PR TITLE
feat: add messages and services for L2/L4 switching

### DIFF
--- a/tier4_external_api_msgs/CMakeLists.txt
+++ b/tier4_external_api_msgs/CMakeLists.txt
@@ -33,6 +33,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/GearShift.msg
   msg/GearShiftStamped.msg
   msg/Heartbeat.msg
+  msg/Level4Availability.msg
+  msg/Level4DrivingStatus.msg
   msg/LocalizationScore.msg
   msg/LocalizationScoreArray.msg
   msg/MapHash.msg
@@ -63,6 +65,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/VehicleStatusStamped.msg
   srv/GetAccelBrakeMapCalibrationData.srv
   srv/ClearRoute.srv
+  srv/EnableLevel4Driving.srv
   srv/Engage.srv
   srv/GetMetadataPackages.srv
   srv/GetRosbagCopyList.srv

--- a/tier4_external_api_msgs/msg/Level4Availability.msg
+++ b/tier4_external_api_msgs/msg/Level4Availability.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+bool is_level4_available

--- a/tier4_external_api_msgs/msg/Level4DrivingStatus.msg
+++ b/tier4_external_api_msgs/msg/Level4DrivingStatus.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+bool is_level4_driving

--- a/tier4_external_api_msgs/srv/EnableLevel4Driving.srv
+++ b/tier4_external_api_msgs/srv/EnableLevel4Driving.srv
@@ -1,0 +1,6 @@
+bool enable_level4_driving
+---
+uint32 ERROR_NOT_INITIALIZED = 5
+uint32 ERROR_INVALID_LEVEL = 6
+uint32 ERROR_CANNOT_START_AUTOWARE = 7
+tier4_external_api_msgs/ResponseStatus status


### PR DESCRIPTION
## Related Links
[INTERNAL_LINK (Confluence)](https://tier4.atlassian.net/wiki/x/Dgax2Q)
[
INTERNAL_LINK (JIRA Ticket)](https://tier4.atlassian.net/browse/RT0-37589?atlOrigin=eyJpIjoiMjllZDc0OGQwOWE0NDM1ZmFmNjQ0MzZjNWM0ODJiZDIiLCJwIjoiaiJ9)

## Description

This PR adds two new message types and a new service type.

- tier4_external_api_msgs/msg/Level4Availability
  - A bool message with a timestamp that tells level4 driving is available.
- tier4_external_api_msgs/msg/Level4DrivingStatus
  - A bool message with a timestamp that tells whether the vehicle is doing level4 driving now.
- tier4_external_api_msgs/srv/EnableLevel4Driving
  - A service to tell the system to do level4 driving or not
  - The request sends a bool variable to start the vehicle with level4 driving or not.
  - The response sends the status in the `tier4_external_api_msgs/msg/ResponseStatus` format.

These messages and service will be used for a new ROS 2 node that manages the driving level in the vehicle which will be like this.
[INTERNAL_LINK (Google Presentation)](https://docs.google.com/presentation/d/1XHXq60Q37LsIjMq9HiJp1SGNlu2qGLH9qGCGHC-oa94/edit?usp=sharing)

## Remarks

The const variables in EnableLevel4Driving starts from 5 since [tier4_external_api_msgs/msg/ResponseStatus](https://github.com/tier4/tier4_autoware_msgs/blob/tier4/universe/tier4_external_api_msgs/msg/ResponseStatus.msg) uses 1 to 4.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
