### PR TITLE
feat(tier4_system_msgs)!: remove unused operation mode msgs

### DIFF
--- a/tier4_system_msgs/CMakeLists.txt
+++ b/tier4_system_msgs/CMakeLists.txt
@@ -43,8 +43,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/CommandModeStatus.msg"
   "msg/CommandModeStatusItem.msg"
   "srv/OperateMrm.srv"
-  "srv/ChangeOperationMode.srv"
-  "srv/ChangeAutowareControl.srv"
   "srv/ChangeTopicRelayControl.srv"
   "srv/ResetDiagGraph.srv"
   "srv/SelectCommandSource.srv"

--- a/tier4_system_msgs/srv/ChangeAutowareControl.srv
+++ b/tier4_system_msgs/srv/ChangeAutowareControl.srv
@@ -1,3 +1,0 @@
-bool autoware_control
----
-autoware_common_msgs/ResponseStatus status

--- a/tier4_system_msgs/srv/ChangeOperationMode.srv
+++ b/tier4_system_msgs/srv/ChangeOperationMode.srv
@@ -1,7 +1,0 @@
-uint16 STOP = 1
-uint16 AUTONOMOUS = 2
-uint16 LOCAL = 3
-uint16 REMOTE = 4
-uint16 mode
----
-autoware_common_msgs/ResponseStatus status


### PR DESCRIPTION
## Related Links

https://github.com/autowarefoundation/autoware_msgs/pull/140

## Description

Remove unused operation mode services. These services are moved to autoware_system_msgs.

## Remarks

None

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
