### PR TITLE
feat(dummyobject): add predict action enum to dummyobject message

### DIFF
--- a/tier4_simulation_msgs/msg/DummyObject.msg
+++ b/tier4_simulation_msgs/msg/DummyObject.msg
@@ -10,4 +10,5 @@ uint8 ADD=0
 uint8 MODIFY=1
 uint8 DELETE=2
 uint8 DELETEALL=3
+uint8 PREDICT=4
 int32 action


### PR DESCRIPTION
- Add PREDICT=4 enum value to tier4_simulation_msgs::msg::DummyObject
- This allows dummy objects to use predicted motion only when explicitly requested 

Needed by: https://github.com/autowarefoundation/autoware_universe/compare/main...tier4:autoware_universe:feat/dummy-object-predicted-path-awf?expand=1

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

<!-- Describe what this PR changes. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code is properly formatted
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
