### PR TITLE
feat(tier4_external_api_msgs): service for manual lane selection

### DIFF
--- a/tier4_external_api_msgs/CMakeLists.txt
+++ b/tier4_external_api_msgs/CMakeLists.txt
@@ -87,6 +87,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   srv/SetOperator.srv
   srv/SetEmergency.srv
   srv/SetPose.srv
+  srv/SetPreferredLane.srv
+  srv/SetPreferredPrimitive.srv
   srv/SetRosbagLoggingMode.srv
   srv/SetRosbagRecord.srv
   srv/SetRosbagRollback.srv
@@ -96,6 +98,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   srv/StartRosbagCopy.srv
   DEPENDENCIES
     builtin_interfaces
+    autoware_common_msgs
+    autoware_planning_msgs
     diagnostic_msgs
     geometry_msgs
     unique_identifier_msgs

--- a/tier4_external_api_msgs/CMakeLists.txt
+++ b/tier4_external_api_msgs/CMakeLists.txt
@@ -88,7 +88,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   srv/SetEmergency.srv
   srv/SetPose.srv
   srv/SetPreferredLane.srv
-  srv/SetPreferredPrimitive.srv
   srv/SetRosbagLoggingMode.srv
   srv/SetRosbagRecord.srv
   srv/SetRosbagRollback.srv

--- a/tier4_external_api_msgs/CMakeLists.txt
+++ b/tier4_external_api_msgs/CMakeLists.txt
@@ -98,7 +98,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES
     builtin_interfaces
     autoware_common_msgs
-    autoware_planning_msgs
     diagnostic_msgs
     geometry_msgs
     unique_identifier_msgs

--- a/tier4_external_api_msgs/package.xml
+++ b/tier4_external_api_msgs/package.xml
@@ -16,7 +16,6 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <depend>autoware_common_msgs</depend>
-  <depend>autoware_planning_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>unique_identifier_msgs</depend>

--- a/tier4_external_api_msgs/package.xml
+++ b/tier4_external_api_msgs/package.xml
@@ -15,6 +15,8 @@
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <depend>autoware_common_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>unique_identifier_msgs</depend>

--- a/tier4_external_api_msgs/srv/SetPreferredLane.srv
+++ b/tier4_external_api_msgs/srv/SetPreferredLane.srv
@@ -1,0 +1,3 @@
+uint8 lane_change_direction
+---
+autoware_common_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetPreferredLane.srv
+++ b/tier4_external_api_msgs/srv/SetPreferredLane.srv
@@ -1,3 +1,9 @@
+# Constants for specifying the direction of lane-change
+uint8 LEFT = 0
+uint8 RIGHT = 1
+uint8 AUTO = 2
+
+# Holds the direction to which the preferred-lanes need to be shifted to
 uint8 lane_change_direction
 ---
 autoware_common_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetPreferredPrimitive.srv
+++ b/tier4_external_api_msgs/srv/SetPreferredPrimitive.srv
@@ -1,4 +1,6 @@
+# Holds the list of preferred_primitives to be modified to in the current-route
 autoware_planning_msgs/LaneletPrimitive[] preferred_primitives
+# Set to true if there has been a modification, holds false otherwise
 bool reset
 unique_identifier_msgs/UUID uuid
 ---

--- a/tier4_external_api_msgs/srv/SetPreferredPrimitive.srv
+++ b/tier4_external_api_msgs/srv/SetPreferredPrimitive.srv
@@ -1,0 +1,5 @@
+autoware_planning_msgs/LaneletPrimitive[] preferred_primitives
+bool reset
+unique_identifier_msgs/UUID uuid
+---
+autoware_common_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetPreferredPrimitive.srv
+++ b/tier4_external_api_msgs/srv/SetPreferredPrimitive.srv
@@ -1,9 +1,0 @@
-# Holds the list of preferred_primitives to be modified to in the current-route
-autoware_planning_msgs/LaneletPrimitive[] preferred_primitives
-# reset flag for preferred primitives in route
-# If set to true, this signals to mission_planner that the preferred-primitives have been reverted to those of the original path
-bool reset
-# ID of the route that will be modified.
-unique_identifier_msgs/UUID uuid
----
-autoware_common_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetPreferredPrimitive.srv
+++ b/tier4_external_api_msgs/srv/SetPreferredPrimitive.srv
@@ -1,7 +1,9 @@
 # Holds the list of preferred_primitives to be modified to in the current-route
 autoware_planning_msgs/LaneletPrimitive[] preferred_primitives
-# Set to true if there has been a modification, holds false otherwise
+# reset flag for preferred primitives in route
+# If set to true, this signals to mission_planner that the preferred-primitives have been reverted to those of the original path
 bool reset
+# ID of the route that will be modified.
 unique_identifier_msgs/UUID uuid
 ---
 autoware_common_msgs/ResponseStatus status


### PR DESCRIPTION
## Related Links
universe PR: ~https://github.com/autowarefoundation/autoware_universe/pull/11043~ https://github.com/autowarefoundation/autoware_universe/pull/11169


- [TIER IV Internal Link](https://tier4.atlassian.net/browse/RT1-10751)

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description
Message changes for https://github.com/autowarefoundation/autoware_universe/pull/11043

Added a new service that allows the user to set preferred-primitives along the current-route; this allows for manually-triggered lane-changes.

A service for the manual-lane change UI has also been added, which specifies the direction of lane-change: either to the left, to the right, or to reset to the autonomous route.

<!-- Describe what this PR changes. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code is properly formatted
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
