### PR TITLE
feat(tier4_external_api_msgs): add system_monitor

### DIFF
--- a/tier4_external_api_msgs/CMakeLists.txt
+++ b/tier4_external_api_msgs/CMakeLists.txt
@@ -21,6 +21,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/ControlCommand.msg
   msg/ControlCommandStamped.msg
   msg/CpuStatus.msg
+  msg/CpuTemperature.msg
   msg/CpuUsage.msg
   msg/DecisionFactorObject.msg
   msg/DecisionFactorPointCloud.msg
@@ -32,11 +33,19 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/FailSafeStateStamped.msg
   msg/GearShift.msg
   msg/GearShiftStamped.msg
+  msg/GpuStatus.msg
+  msg/GpuUnitStatus.msg
   msg/Heartbeat.msg
+  msg/HddDeviceStatus.msg
+  msg/HddPartitionStatus.msg
+  msg/HddStatus.msg
   msg/LocalizationScore.msg
   msg/LocalizationScoreArray.msg
   msg/MapHash.msg
   msg/MetadataPackages.msg
+  msg/MemoryStatus.msg
+  msg/NetworkInterfaceStatus.msg
+  msg/NetworkStatus.msg
   msg/Observer.msg
   msg/Operator.msg
   msg/PlanningFactor.msg
@@ -52,6 +61,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/RouteSection.msg
   msg/Service.msg
   msg/Steering.msg
+  msg/SystemMonitor.msg
   msg/TextFile.msg
   msg/TrafficLightElement.msg
   msg/TrafficLightGroup.msg

--- a/tier4_external_api_msgs/msg/CpuTemperature.msg
+++ b/tier4_external_api_msgs/msg/CpuTemperature.msg
@@ -1,0 +1,9 @@
+# constants
+uint8 THERMAL_THROTTLING_OFF=0
+uint8 THERMAL_THROTTLING_ON=1
+
+#fields
+builtin_interfaces/Time stamp
+string hostname
+float32 temperature        # [degC]
+uint8  thermal_throttling  # 0(OFF) or 1(ON)

--- a/tier4_external_api_msgs/msg/GpuStatus.msg
+++ b/tier4_external_api_msgs/msg/GpuStatus.msg
@@ -1,0 +1,3 @@
+builtin_interfaces/Time stamp
+string hostname
+GpuUnitStatus[] gpus

--- a/tier4_external_api_msgs/msg/GpuUnitStatus.msg
+++ b/tier4_external_api_msgs/msg/GpuUnitStatus.msg
@@ -1,0 +1,10 @@
+# constants
+uint8 THERMAL_THROTTLING_OFF=0
+uint8 THERMAL_THROTTLING_ON=1
+
+#fields
+string name
+float32 usage              # [%]
+uint32 clock               # [MHz]
+uint32 temperature         # [degC]
+uint8  thermal_throttling  # 0(OFF) or 1(ON)

--- a/tier4_external_api_msgs/msg/HddDeviceStatus.msg
+++ b/tier4_external_api_msgs/msg/HddDeviceStatus.msg
@@ -1,0 +1,5 @@
+string name              # Device name
+float32 read_data_rate   # [MB/s] data rate of read
+float32 write_data_rate  # [MB/s] data rate of write
+float32 read_iops        # [IOPS] IOPS of read
+float32 write_iops       # [IOPS] IOPS of write

--- a/tier4_external_api_msgs/msg/HddPartitionStatus.msg
+++ b/tier4_external_api_msgs/msg/HddPartitionStatus.msg
@@ -1,0 +1,6 @@
+int32 size         # [MB] Total size of the filesystem
+int32 used         # [MB] Used space in the filesystem
+int32 avail        # [MB] Available (free) space in the filesystem
+int32 capacity     # [%]  Percentage of used space in the filesystem
+string filesystem  # Name of the filesystem device (e.g., "/dev/nvme0n1p2")
+string mounted_on  # Mount point of the filesystem  (e.g., "/")

--- a/tier4_external_api_msgs/msg/HddStatus.msg
+++ b/tier4_external_api_msgs/msg/HddStatus.msg
@@ -1,0 +1,4 @@
+builtin_interfaces/Time stamp
+string hostname
+HddDeviceStatus[] devices
+HddPartitionStatus[] partitions

--- a/tier4_external_api_msgs/msg/MemoryStatus.msg
+++ b/tier4_external_api_msgs/msg/MemoryStatus.msg
@@ -1,0 +1,3 @@
+builtin_interfaces/Time stamp
+string hostname
+float32 usage  # [%] DDR memory usage

--- a/tier4_external_api_msgs/msg/NetworkInterfaceStatus.msg
+++ b/tier4_external_api_msgs/msg/NetworkInterfaceStatus.msg
@@ -1,0 +1,7 @@
+string name         # Interface name
+float32 rx_traffic  # [MBit/s] Traffic received
+float32 tx_traffic  # [MBit/s] Traffic transmitted
+float32 capacity    # [MBit/s] Network capacity
+uint32 rx_errors    # [count] Total number of reception errors
+uint32 tx_errors    # [count] Total number of transmission errors
+uint32 collisions   # [count] Total number of collisions during packet transmissions

--- a/tier4_external_api_msgs/msg/NetworkStatus.msg
+++ b/tier4_external_api_msgs/msg/NetworkStatus.msg
@@ -1,0 +1,6 @@
+builtin_interfaces/Time stamp
+string hostname
+NetworkInterfaceStatus[] interfaces
+uint32 error_ip_packet_reassembles_failed  # [count/unit time] Rate of failed IP fragment reassembly events
+uint32 error_udp_buf_rx                    # [count/unit time] Rate of dropped incoming UDP packets
+uint32 error_udp_buf_tx                    # [count/unit time] Rate of failed outgoing UDP packets

--- a/tier4_external_api_msgs/msg/SystemMonitor.msg
+++ b/tier4_external_api_msgs/msg/SystemMonitor.msg
@@ -1,0 +1,7 @@
+builtin_interfaces/Time stamp
+string hostname
+CpuTemperature cpu_temperature
+MemoryStatus memory_status
+GpuStatus gpu_status
+NetworkStatus network_status
+HddStatus hdd_status


### PR DESCRIPTION
Backport of https://github.com/tier4/tier4_autoware_msgs/pull/187 to `beta/v0.48` branch


## Related Links

- JIRA Ticket
  - https://tier4.atlassian.net/browse/RT0-38268
- Related documents
  - https://tier4.atlassian.net/wiki/spaces/SI/pages/3644819134
- This PR is necessary for the following PRs
  - https://github.com/tier4/tier4_ad_api_adaptor/pull/166
  - https://github.com/autowarefoundation/autoware_universe/pull/11024
  - https://github.com/autowarefoundation/autoware_universe/pull/11023
  - https://github.com/autowarefoundation/autoware_universe/pull/11022
  - https://github.com/autowarefoundation/autoware_universe/pull/11021
  - https://github.com/autowarefoundation/autoware_universe/pull/11020

## Description

- This PR is one of the PRs needed for metrics collection
- This PR adds messages related to system performance ([SystemMonitor.msg](https://github.com/tier4/tier4_autoware_msgs/pull/187/files#diff-0d8642cd09074652a188c0ebc1e931a96432fa0b1845fd00eb17ac5ba209507d)) , which is the message definition of `/api/external/get/system_monito` API([This PR](https://github.com/tier4/tier4_ad_api_adaptor/pull/166) adds the API)
- `/api/external/get/system_monito` API is received by [Metric Agent](https://github.com/tier4/autoware-metric-agent)

## Remarks

### Considerations in this PR

- Whether to consolidate messages into one or separate them:

  - It is possible to create individual APIs for each metric. However, in most cases, users who are interested in system performance prefer to have multiple metrics combined in one message. Additionally, in ROS2, separating messages requires multiple subscriptions, which may degrade performance. Considering usability and performance, we decided to consolidate all metrics into a single message.

- Message format: key-value pairs vs. individually defined fields:
  - Both the sender (API adaptor and System Monitor) and receiver (Metric Agent) of this message operate on the same ECU and are built at the same time. Therefore, the risk of compatibility issues caused by defining fields individually is low. Moreover, there is a request to avoid parsing messages to extract information([Confluence](https://tier4.atlassian.net/wiki/spaces/SI/pages/3644819134)). For these reasons, we chose to define each field individually instead of using a key-value format.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
