### PR TITLE
feat(planning): add Waypoint Following scenario and SaveWaypoint service

### DIFF
--- a/tier4_planning_msgs/CMakeLists.txt
+++ b/tier4_planning_msgs/CMakeLists.txt
@@ -54,6 +54,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/ClearRoute.srv"
   "srv/SetLaneletRoute.srv"
   "srv/SetWaypointRoute.srv"
+  "srv/SaveWaypoint.srv"
   DEPENDENCIES
     autoware_common_msgs
     autoware_planning_msgs

--- a/tier4_planning_msgs/msg/Scenario.msg
+++ b/tier4_planning_msgs/msg/Scenario.msg
@@ -1,6 +1,7 @@
 string EMPTY=Empty
 string LANEDRIVING=LaneDriving
 string PARKING=Parking
+string WAYPOINTFOLLOWING=WaypointFollowing
 
 string current_scenario
 string[] activating_scenarios

--- a/tier4_planning_msgs/srv/SaveWaypoint.srv
+++ b/tier4_planning_msgs/srv/SaveWaypoint.srv
@@ -1,0 +1,7 @@
+# Save.srv
+
+bool mode  
+float32 interval
+---
+string file_name
+bool success


### PR DESCRIPTION
## Related Links
- autoware universe
https://github.com/autowarefoundation/autoware_universe/pull/11292

## Description
This PR extends `tier4_planning_msgs` with support for Waypoint Following:

- Added `WAYPOINTFOLLOWING=WaypointFollowing` to `Scenario.msg`.
- Added new service definition `SaveWaypoint.srv` for saving waypoints:
  - `bool mode` – recording mode flag
  - `float32 interval` – waypoint recording interval
  - `string file_name` – target file name
  - `bool success` – result of the operation
- Updated `CMakeLists.txt` to include the new service.

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
