### PR TITLE
feat(tier4_external_api_msgs): service for manual lane selection

### DIFF
--- a/tier4_external_api_msgs/CMakeLists.txt
+++ b/tier4_external_api_msgs/CMakeLists.txt
@@ -86,6 +86,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   srv/SetOperator.srv
   srv/SetEmergency.srv
   srv/SetPose.srv
+  srv/SetPreferredLane.srv
   srv/SetRosbagLoggingMode.srv
   srv/SetRosbagRecord.srv
   srv/SetRosbagRollback.srv
@@ -95,6 +96,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   srv/StartRosbagCopy.srv
   DEPENDENCIES
     builtin_interfaces
+    autoware_common_msgs
     diagnostic_msgs
     geometry_msgs
     unique_identifier_msgs

--- a/tier4_external_api_msgs/package.xml
+++ b/tier4_external_api_msgs/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <depend>autoware_common_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>unique_identifier_msgs</depend>

--- a/tier4_external_api_msgs/srv/SetPreferredLane.srv
+++ b/tier4_external_api_msgs/srv/SetPreferredLane.srv
@@ -1,0 +1,9 @@
+# Constants for specifying the direction of lane-change
+uint8 LEFT = 0
+uint8 RIGHT = 1
+uint8 AUTO = 2
+
+# Holds the direction to which the preferred-lanes need to be shifted to
+uint8 lane_change_direction
+---
+autoware_common_msgs/ResponseStatus status


### PR DESCRIPTION
## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

Message changes for https://github.com/autowarefoundation/autoware_universe/pull/11043

Added a new service that allows the user to set preferred-primitives along the current-route; this allows for manually-triggered lane-changes.

A service for the manual-lane change UI has also been added, which specifies the direction of lane-change: either to the left, to the right, or to reset to the autonomous route.

<!-- Describe what this PR changes. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code is properly formatted
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
