### PR TITLE
docs: add unit and range documentation to message fields

### DIFF
--- a/tier4_external_api_msgs/msg/ControlCommand.msg
+++ b/tier4_external_api_msgs/msg/ControlCommand.msg
@@ -1,4 +1,8 @@
+# Steering angle [rad]. Positive: left, Negative: right
 float64 steering_angle
+# Steering angle velocity [rad/s]
 float64 steering_angle_velocity
+# Throttle command. Range: 0.0 to 1.0 (normalized)
 float64 throttle
+# Brake command. Range: 0.0 to 1.0 (normalized)
 float64 brake

--- a/tier4_external_api_msgs/msg/CpuStatus.msg
+++ b/tier4_external_api_msgs/msg/CpuStatus.msg
@@ -1,13 +1,19 @@
-# constants
-uint8 OK=0
-uint8 HIGH_LOAD=1
-uint8 VERY_HIGH_LOAD=2
-uint8 STALE=3
+# constants for status
+uint8 OK=0              # CPU load is normal
+uint8 HIGH_LOAD=1       # CPU load is high
+uint8 VERY_HIGH_LOAD=2  # CPU load is very high
+uint8 STALE=3           # CPU status data is stale/outdated
 
-#fields
+# fields
+# CPU load status (use constants above)
 uint8 status
+# Total CPU usage [%]. Range: 0.0 to 100.0
 float32 total
+# User space CPU usage [%]. Range: 0.0 to 100.0
 float32 usr
+# Nice priority CPU usage [%]. Range: 0.0 to 100.0
 float32 nice
+# Kernel space CPU usage [%]. Range: 0.0 to 100.0
 float32 sys
+# Idle CPU [%]. Range: 0.0 to 100.0
 float32 idle

--- a/tier4_external_api_msgs/msg/LocalizationScore.msg
+++ b/tier4_external_api_msgs/msg/LocalizationScore.msg
@@ -1,2 +1,9 @@
+# constants for name
+string TRANSFORM_PROBABILITY = "transform_probability"
+string NEAREST_VOXEL_TRANSFORMATION_LIKELIHOOD = "nearest_voxel_transformation_likelihood"
+
+# fields
+# Score type name (use constants above)
 string name
+# Localization score value. Range depends on the score type
 float32 value

--- a/tier4_external_api_msgs/msg/ResponseStatus.msg
+++ b/tier4_external_api_msgs/msg/ResponseStatus.msg
@@ -1,9 +1,11 @@
-# constants
-uint32 SUCCESS=1
-uint32 IGNORED=2
-uint32 WARN=3
-uint32 ERROR=4
+# constants for code
+uint32 SUCCESS=1  # Operation completed successfully
+uint32 IGNORED=2  # Request was ignored (e.g., already in requested state)
+uint32 WARN=3     # Operation completed with warnings
+uint32 ERROR=4    # Operation failed
 
 # fields
+# Response status code (use constants above)
 uint32 code
+# Human-readable status message
 string message

--- a/tier4_external_api_msgs/msg/RouteDistance.msg
+++ b/tier4_external_api_msgs/msg/RouteDistance.msg
@@ -1,2 +1,3 @@
 builtin_interfaces/Time stamp
+# Remaining distance to the goal [m]. Range: >= 0.0
 float64 remaining_distance

--- a/tier4_external_api_msgs/msg/TrafficLightElement.msg
+++ b/tier4_external_api_msgs/msg/TrafficLightElement.msg
@@ -24,8 +24,12 @@ uint8 SOLID_OFF = 1
 uint8 SOLID_ON = 2
 uint8 FLASHING = 3
 
-# variables
+# fields
+# Traffic light color (use color constants above, or UNKNOWN)
 uint8 color
+# Traffic light shape (use shape constants above, or UNKNOWN)
 uint8 shape
+# Traffic light status (use status constants above, or UNKNOWN)
 uint8 status
+# Detection confidence. Range: 0.0 to 1.0
 float32 confidence

--- a/tier4_external_api_msgs/msg/VelocityLimit.msg
+++ b/tier4_external_api_msgs/msg/VelocityLimit.msg
@@ -1,2 +1,3 @@
 builtin_interfaces/Time stamp
+# Velocity limit [m/s]. Range: >= 0.0
 float32 velocity

--- a/tier4_external_api_msgs/srv/SetVelocityLimit.srv
+++ b/tier4_external_api_msgs/srv/SetVelocityLimit.srv
@@ -1,3 +1,4 @@
+# Velocity limit to set [m/s]. Range: >= 0.0
 float32 velocity
 ---
 tier4_external_api_msgs/ResponseStatus status


### PR DESCRIPTION
## Related Links

Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106

## Description

Add inline documentation comments to clarify units and valid ranges for message fields in tier4_external_api_msgs:

- `VelocityLimit.msg`: velocity unit [m/s], range >= 0.0
- `SetVelocityLimit.srv`: velocity unit [m/s], range >= 0.0
- `CpuStatus.msg`: CPU usage [%] range 0.0-100.0, status constant descriptions
- `TrafficLightElement.msg`: confidence range 0.0-1.0
- `LocalizationScore.msg`: string constants for name field
- `ControlCommand.msg`: throttle/brake range 0.0-1.0, steering angle [rad]
- `RouteDistance.msg`: remaining_distance unit [m], range >= 0.0
- `ResponseStatus.msg`: status code constant descriptions

## Remarks

Documentation-only changes. No functional changes.

## Pre-Review Checklist for the PR Author

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute