### PR TITLE
docs: add documentation to remaining msg/srv fields

### DIFF
--- a/tier4_api_msgs/msg/VelocityLimit.msg
+++ b/tier4_api_msgs/msg/VelocityLimit.msg
@@ -1,2 +1,5 @@
+# Timestamp of the velocity limit
 builtin_interfaces/Time stamp
+
+# Maximum velocity [m/s]. Range: >= 0.0
 float32 max_velocity

--- a/tier4_api_msgs/msg/VelocityLimit.msg
+++ b/tier4_api_msgs/msg/VelocityLimit.msg
@@ -1,4 +1,3 @@
-# Timestamp of the velocity limit
 builtin_interfaces/Time stamp
 
 # Maximum velocity [m/s]. Range: >= 0.0

--- a/tier4_control_msgs/srv/SetPause.srv
+++ b/tier4_control_msgs/srv/SetPause.srv
@@ -1,3 +1,5 @@
+# Pause state
+# true: pause vehicle motion, false: resume vehicle motion
 bool pause
 ---
 autoware_common_msgs/ResponseStatus status

--- a/tier4_control_msgs/srv/SetStop.srv
+++ b/tier4_control_msgs/srv/SetStop.srv
@@ -1,4 +1,8 @@
+# Stop state
+# true: request vehicle to stop, false: cancel stop request
 bool stop
+
+# Identifier of the module or component requesting the stop
 string request_source
 ---
 autoware_common_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/msg/Emergency.msg
+++ b/tier4_external_api_msgs/msg/Emergency.msg
@@ -1,4 +1,3 @@
-# Timestamp of the emergency state
 builtin_interfaces/Time stamp
 
 # Emergency state

--- a/tier4_external_api_msgs/msg/Emergency.msg
+++ b/tier4_external_api_msgs/msg/Emergency.msg
@@ -1,2 +1,6 @@
+# Timestamp of the emergency state
 builtin_interfaces/Time stamp
+
+# Emergency state
+# true: emergency stop is active, false: normal operation
 bool emergency

--- a/tier4_external_api_msgs/msg/EngageStatus.msg
+++ b/tier4_external_api_msgs/msg/EngageStatus.msg
@@ -1,2 +1,6 @@
+# Timestamp of the engage status
 builtin_interfaces/Time stamp
+
+# Engage state
+# true: autonomous driving is engaged, false: autonomous driving is disengaged
 bool engage

--- a/tier4_external_api_msgs/msg/EngageStatus.msg
+++ b/tier4_external_api_msgs/msg/EngageStatus.msg
@@ -1,4 +1,3 @@
-# Timestamp of the engage status
 builtin_interfaces/Time stamp
 
 # Engage state

--- a/tier4_external_api_msgs/msg/FailSafeState.msg
+++ b/tier4_external_api_msgs/msg/FailSafeState.msg
@@ -1,9 +1,9 @@
 # constants
-uint8 NORMAL = 1
-uint8 OVERRIDE_REQUESTING = 2
-uint8 MRM_OPERATING = 3
-uint8 MRM_SUCCEEDED = 4
-uint8 MRM_FAILED = 5
+uint8 NORMAL = 1              # System is operating normally
+uint8 OVERRIDE_REQUESTING = 2 # System is requesting driver override
+uint8 MRM_OPERATING = 3       # Minimal Risk Maneuver is in progress
+uint8 MRM_SUCCEEDED = 4       # Minimal Risk Maneuver completed successfully
+uint8 MRM_FAILED = 5          # Minimal Risk Maneuver failed
 
 # fields
 uint8 state

--- a/tier4_external_api_msgs/msg/Route.msg
+++ b/tier4_external_api_msgs/msg/Route.msg
@@ -1,2 +1,5 @@
+# Goal pose for the route
 geometry_msgs/PoseStamped goal_pose
+
+# Ordered list of route sections from start to goal
 tier4_external_api_msgs/RouteSection[] route_sections

--- a/tier4_external_api_msgs/msg/Steering.msg
+++ b/tier4_external_api_msgs/msg/Steering.msg
@@ -1,1 +1,3 @@
+# Steering tire angle [rad]
+# Positive value represents left turn, negative value represents right turn
 float32 data

--- a/tier4_external_api_msgs/msg/VehicleCommand.msg
+++ b/tier4_external_api_msgs/msg/VehicleCommand.msg
@@ -1,5 +1,5 @@
 # Target longitudinal velocity [m/s]
 float64 velocity
 
-# Target longitudinal acceleration [m/s²]
+# Target longitudinal acceleration [m/s^2]
 float64 acceleration

--- a/tier4_external_api_msgs/msg/VehicleCommand.msg
+++ b/tier4_external_api_msgs/msg/VehicleCommand.msg
@@ -1,2 +1,5 @@
+# Target longitudinal velocity [m/s]
 float64 velocity
+
+# Target longitudinal acceleration [m/s²]
 float64 acceleration

--- a/tier4_external_api_msgs/msg/VehicleStatus.msg
+++ b/tier4_external_api_msgs/msg/VehicleStatus.msg
@@ -1,4 +1,11 @@
+# Current vehicle velocity and angular velocity
 geometry_msgs/Twist twist
+
+# Current steering state
 tier4_external_api_msgs/Steering steering
+
+# Current turn signal state
 tier4_external_api_msgs/TurnSignal turn_signal
+
+# Current gear shift state
 tier4_external_api_msgs/GearShift gear_shift

--- a/tier4_external_api_msgs/srv/ClearRoute.srv
+++ b/tier4_external_api_msgs/srv/ClearRoute.srv
@@ -1,2 +1,3 @@
+# Clear the current route
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/Engage.srv
+++ b/tier4_external_api_msgs/srv/Engage.srv
@@ -1,3 +1,5 @@
+# Engage state to set
+# true: engage autonomous driving, false: disengage autonomous driving
 bool engage
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/GetAccelBrakeMapCalibrationData.srv
+++ b/tier4_external_api_msgs/srv/GetAccelBrakeMapCalibrationData.srv
@@ -1,4 +1,10 @@
+# Get acceleration and brake map calibration data
 ---
+# Graph image as PNG byte array
 uint8[] graph_image
+
+# Acceleration map data in CSV format
 string accel_map
+
+# Brake map data in CSV format
 string brake_map

--- a/tier4_external_api_msgs/srv/GetRosbagCopyList.srv
+++ b/tier4_external_api_msgs/srv/GetRosbagCopyList.srv
@@ -1,3 +1,6 @@
+# Get list of rosbag directories available for copy
 ---
 tier4_external_api_msgs/ResponseStatus status
+
+# Newline-separated list of directory paths available for copy
 string copy_directory_list

--- a/tier4_external_api_msgs/srv/InitializePose.srv
+++ b/tier4_external_api_msgs/srv/InitializePose.srv
@@ -1,3 +1,4 @@
+# Initial pose with covariance for localization initialization
 geometry_msgs/PoseWithCovarianceStamped pose
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/InitializePoseAuto.srv
+++ b/tier4_external_api_msgs/srv/InitializePoseAuto.srv
@@ -1,2 +1,3 @@
+# Automatically initialize vehicle pose using sensors (e.g., GNSS)
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/PauseDriving.srv
+++ b/tier4_external_api_msgs/srv/PauseDriving.srv
@@ -1,3 +1,5 @@
+# Pause state to set
+# true: pause driving (vehicle stops), false: resume driving
 bool pause
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/ResetRedundancySwitcher.srv
+++ b/tier4_external_api_msgs/srv/ResetRedundancySwitcher.srv
@@ -1,2 +1,3 @@
+# Reset the redundancy switcher to its initial state
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetDoor.srv
+++ b/tier4_external_api_msgs/srv/SetDoor.srv
@@ -1,3 +1,5 @@
+# Door command
+# true: open door, false: close door
 bool open
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetEmergency.srv
+++ b/tier4_external_api_msgs/srv/SetEmergency.srv
@@ -1,3 +1,5 @@
+# Emergency state to set
+# true: activate emergency stop, false: deactivate emergency stop
 bool emergency
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetObserver.srv
+++ b/tier4_external_api_msgs/srv/SetObserver.srv
@@ -1,3 +1,4 @@
+# Observer mode to set
 tier4_external_api_msgs/Observer mode
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetOperator.srv
+++ b/tier4_external_api_msgs/srv/SetOperator.srv
@@ -1,3 +1,4 @@
+# Operator mode to set
 tier4_external_api_msgs/Operator mode
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetPose.srv
+++ b/tier4_external_api_msgs/srv/SetPose.srv
@@ -1,3 +1,4 @@
+# Target pose to set
 geometry_msgs/PoseStamped pose
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetRosbagLoggingMode.srv
+++ b/tier4_external_api_msgs/srv/SetRosbagLoggingMode.srv
@@ -1,3 +1,5 @@
+# Rosbag logging mode
+# true: operation mode (logs essential topics only), false: debug mode (logs all topics)
 bool is_operation_mode
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetRosbagRecord.srv
+++ b/tier4_external_api_msgs/srv/SetRosbagRecord.srv
@@ -1,3 +1,5 @@
+# Recording state
+# true: start recording, false: stop recording
 bool record
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetRosbagRollback.srv
+++ b/tier4_external_api_msgs/srv/SetRosbagRollback.srv
@@ -1,3 +1,5 @@
+# Rollback command
+# true: perform rollback to discard recent recording, false: no action
 bool rollback
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetRoute.srv
+++ b/tier4_external_api_msgs/srv/SetRoute.srv
@@ -1,3 +1,4 @@
+# Route to set for navigation
 tier4_external_api_msgs/Route route
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_external_api_msgs/srv/SetService.srv
+++ b/tier4_external_api_msgs/srv/SetService.srv
@@ -1,3 +1,4 @@
+# Service mode to set
 tier4_external_api_msgs/Service mode
 ---
 tier4_external_api_msgs/ResponseStatus status

--- a/tier4_perception_msgs/msg/object_recognition/Semantic.msg
+++ b/tier4_perception_msgs/msg/object_recognition/Semantic.msg
@@ -1,3 +1,4 @@
+# Object classification types
 uint8 UNKNOWN=0
 uint8 CAR=1
 uint8 TRUCK=2
@@ -6,5 +7,9 @@ uint8 BICYCLE=4
 uint8 MOTORBIKE=5
 uint8 PEDESTRIAN=6
 uint8 ANIMAL=7
+
+# Classification type (use constants above)
 uint32 type
+
+# Classification confidence score. Range: 0.0 to 1.0
 float64 confidence

--- a/tier4_perception_msgs/msg/object_recognition/State.msg
+++ b/tier4_perception_msgs/msg/object_recognition/State.msg
@@ -1,7 +1,20 @@
+# Object pose with covariance
 geometry_msgs/PoseWithCovariance pose_covariance
+
+# true: orientation estimation is reliable, false: orientation may be uncertain
 bool orientation_reliable
+
+# Object velocity with covariance
 geometry_msgs/TwistWithCovariance twist_covariance
+
+# true: velocity estimation is reliable, false: velocity may be uncertain
 bool twist_reliable
+
+# Object acceleration with covariance
 geometry_msgs/AccelWithCovariance acceleration_covariance
+
+# true: acceleration estimation is reliable, false: acceleration may be uncertain
 bool acceleration_reliable
+
+# Predicted future paths of the object
 PredictedPath[] predicted_paths

--- a/tier4_planning_msgs/msg/ControlPoint.msg
+++ b/tier4_planning_msgs/msg/ControlPoint.msg
@@ -1,4 +1,12 @@
+# Pose of the control point
 geometry_msgs/Pose pose
+
+# Velocity at this control point [m/s]
 float32 velocity
+
+# Lateral shift length from the reference path [m]
+# Positive value represents left shift, negative value represents right shift
 float32 shift_length
+
+# Distance from the ego vehicle to this control point [m]
 float32 distance

--- a/tier4_planning_msgs/msg/ExpandStopRange.msg
+++ b/tier4_planning_msgs/msg/ExpandStopRange.msg
@@ -1,2 +1,5 @@
+# Timestamp of the expand stop range
 builtin_interfaces/Time stamp
+
+# Additional distance [m] to expand the stop detection range
 float32 expand_stop_range

--- a/tier4_planning_msgs/msg/ExpandStopRange.msg
+++ b/tier4_planning_msgs/msg/ExpandStopRange.msg
@@ -1,4 +1,3 @@
-# Timestamp of the expand stop range
 builtin_interfaces/Time stamp
 
 # Additional distance [m] to expand the stop detection range

--- a/tier4_planning_msgs/msg/LateralOffset.msg
+++ b/tier4_planning_msgs/msg/LateralOffset.msg
@@ -1,4 +1,3 @@
-# Timestamp of the lateral offset
 builtin_interfaces/Time stamp
 
 # Lateral offset from the reference path [m]

--- a/tier4_planning_msgs/msg/LateralOffset.msg
+++ b/tier4_planning_msgs/msg/LateralOffset.msg
@@ -1,2 +1,6 @@
+# Timestamp of the lateral offset
 builtin_interfaces/Time stamp
+
+# Lateral offset from the reference path [m]
+# Positive value represents left offset, negative value represents right offset
 float32 lateral_offset


### PR DESCRIPTION
## Related Links

- Continuation of #205

## Description

Add documentation comments to remaining message and service definition files to improve API clarity:

- Document units (rad, m/s, m)
- Document value ranges (e.g., 0.0-1.0 for confidence)
- Clarify boolean semantics (true/false meanings)

### Modified Packages
- tier4_external_api_msgs (msg and srv)
- tier4_api_msgs (msg)
- tier4_planning_msgs (msg)
- tier4_perception_msgs (msg)
- tier4_control_msgs (srv)

## Remarks

33 files modified in total.

## Pre-Review Checklist for the PR Author

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute