### PR TITLE
feat(tier4_external_api_msgs): add hazard status

### DIFF
--- a/tier4_external_api_msgs/CMakeLists.txt
+++ b/tier4_external_api_msgs/CMakeLists.txt
@@ -35,6 +35,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/GearShiftStamped.msg
   msg/GpuStatus.msg
   msg/GpuUnitStatus.msg
+  msg/HazardStatus.msg
+  msg/HazardStatusStamped.msg
   msg/Heartbeat.msg
   msg/HddDeviceStatus.msg
   msg/HddPartitionStatus.msg

--- a/tier4_external_api_msgs/msg/HazardStatus.msg
+++ b/tier4_external_api_msgs/msg/HazardStatus.msg
@@ -1,0 +1,12 @@
+# This message is deprecated and will be removed in 2026/09.
+uint8 NO_FAULT = 0
+uint8 SAFE_FAULT = 1
+uint8 LATENT_FAULT = 2
+uint8 SINGLE_POINT_FAULT = 3
+uint8 level
+bool emergency
+bool emergency_holding
+diagnostic_msgs/DiagnosticStatus[] diag_no_fault
+diagnostic_msgs/DiagnosticStatus[] diag_safe_fault
+diagnostic_msgs/DiagnosticStatus[] diag_latent_fault
+diagnostic_msgs/DiagnosticStatus[] diag_single_point_fault

--- a/tier4_external_api_msgs/msg/HazardStatusStamped.msg
+++ b/tier4_external_api_msgs/msg/HazardStatusStamped.msg
@@ -1,0 +1,3 @@
+# This message is deprecated and will be removed in 2026/09.
+builtin_interfaces/Time stamp
+tier4_external_api_msgs/HazardStatus status


### PR DESCRIPTION
## Description
Add message to extend support for hazard status.

## Related links
[TIER IV internal link](https://star4.slack.com/archives/C017VB9UG1L/p1764755261143539?thread_ts=1729675438.504999&cid=C017VB9UG1L)

https://github.com/tier4/autoware_universe/pull/2640
https://github.com/tier4/tier4_ad_api_adaptor/pull/200

[Source PR](https://github.com/tier4/tier4_autoware_msgs/pull/201)

## How was this PR tested?
Please refer to [PR#2640](https://github.com/tier4/autoware_universe/pull/2640)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
