### PR TITLE
feat: add SetLateralOffset service for side shift

### DIFF
--- a/tier4_planning_msgs/CMakeLists.txt
+++ b/tier4_planning_msgs/CMakeLists.txt
@@ -53,6 +53,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/VelocityLimitConstraints.msg"
   "srv/ClearRoute.srv"
   "srv/SetLaneletRoute.srv"
+  "srv/SetLateralOffset.srv"
   "srv/SetWaypointRoute.srv"
   DEPENDENCIES
     autoware_common_msgs

--- a/tier4_planning_msgs/srv/SetLateralOffset.srv
+++ b/tier4_planning_msgs/srv/SetLateralOffset.srv
@@ -17,7 +17,7 @@ float32 shift_value
 # When shift_mode = LATERAL_OFFSET_DIRECTION
 uint8 shift_direction_value
 ---
-# These constants define values for autoware_common_msgs/ResponseStatus.code in this service response.
+# Constants for response_code
 
 # No result has been assigned yet.
 uint16 UNKNOWN = 0
@@ -39,5 +39,9 @@ uint16 ERROR_MODULES_CONFLICTING = 10005
 uint16 WARN_UNKNOWN = 20000
 # The requested shift exceeded the limit and was clamped to the maximum allowed offset.
 uint16 WARN_EXCEEDED_LIMIT = 20001
+
+# response_code uses the constants above, and may also use autoware_common_msgs/msg/ResponseStatus.code
+# values with the same numeric definitions; this service uses SERVICE_UNREADY and PARAMETER_ERROR in that way.
+uint16 response_code
 
 autoware_common_msgs/ResponseStatus status

--- a/tier4_planning_msgs/srv/SetLateralOffset.srv
+++ b/tier4_planning_msgs/srv/SetLateralOffset.srv
@@ -18,7 +18,8 @@ float32 shift_value
 uint8 shift_direction_value
 ---
 # code
-uint16 SUCCESS = 0
+uint16 UNKNOWN = 0
+uint16 SUCCESS = 1
 uint16 ERROR_UNKNOWN = 10000
 uint16 ERROR_INVALID_MODE = 10001
 uint16 ERROR_INVALID_DIRECTION = 10002

--- a/tier4_planning_msgs/srv/SetLateralOffset.srv
+++ b/tier4_planning_msgs/srv/SetLateralOffset.srv
@@ -17,16 +17,27 @@ float32 shift_value
 # When shift_mode = LATERAL_OFFSET_DIRECTION
 uint8 shift_direction_value
 ---
-# code
+# These constants define values for autoware_common_msgs/ResponseStatus.code in this service response.
+
+# No result has been assigned yet.
 uint16 UNKNOWN = 0
+# The request was accepted and the lateral offset was updated.
 uint16 SUCCESS = 1
+# An unspecified error occurred.
 uint16 ERROR_UNKNOWN = 10000
+# The shift_mode value is not supported.
 uint16 ERROR_INVALID_MODE = 10001
+# The shift_direction_value is invalid for LATERAL_OFFSET_DIRECTION mode.
 uint16 ERROR_INVALID_DIRECTION = 10002
+# The lateral offset is ALREADY at the limit, and cannot be shifted further.
 uint16 ERROR_EXCEEDED_LIMIT = 10003
+# The requested change is too small to perform a meaningful shift.
 uint16 ERROR_SHIFT_GAP_TOO_SMALL = 10004
+# Other active modules in the behavior path planner conflict with this operation.
 uint16 ERROR_MODULES_CONFLICTING = 10005
+# An unspecified warning occurred.
 uint16 WARN_UNKNOWN = 20000
+# The requested shift exceeded the limit and was clamped to the maximum allowed offset.
 uint16 WARN_EXCEEDED_LIMIT = 20001
 
 autoware_common_msgs/ResponseStatus status

--- a/tier4_planning_msgs/srv/SetLateralOffset.srv
+++ b/tier4_planning_msgs/srv/SetLateralOffset.srv
@@ -1,8 +1,8 @@
 # Options for shift_mode
 uint8 EXPLICIT_LATERAL_OFFSET_AMOUNT = 1
-uint8 DIRECTION = 2
+uint8 LATERAL_OFFSET_DIRECTION = 2
 
-# Options for shift_direction_value (used when shift_mode = DIRECTION)
+# Options for shift_direction_value (used when shift_mode = LATERAL_OFFSET_DIRECTION)
 uint8 RESET = 0
 uint8 LEFT = 1
 uint8 RIGHT = 2
@@ -14,7 +14,7 @@ uint8 shift_mode
 # positive -> left of the reference path, negative -> right of the reference path
 float32 shift_value
 
-# When shift_mode = DIRECTION
+# When shift_mode = LATERAL_OFFSET_DIRECTION
 uint8 shift_direction_value
 ---
 # code

--- a/tier4_planning_msgs/srv/SetLateralOffset.srv
+++ b/tier4_planning_msgs/srv/SetLateralOffset.srv
@@ -1,0 +1,18 @@
+# Options for shift_mode
+uint8 RAW_VALUE = 1
+uint8 DIRECTION = 2
+
+# Options for shift_direction_value
+uint8 RESET = 0
+uint8 LEFT = 1
+uint8 RIGHT = 2
+
+uint8 shift_mode
+
+# When shift_mode = RAW_VALUE (in meters)
+float32 shift_value
+
+# When shift_mode = DIRECTION
+uint8 shift_direction_value
+---
+autoware_common_msgs/ResponseStatus status

--- a/tier4_planning_msgs/srv/SetLateralOffset.srv
+++ b/tier4_planning_msgs/srv/SetLateralOffset.srv
@@ -1,15 +1,17 @@
 # Options for shift_mode
-uint8 RAW_VALUE = 1
+uint8 EXPLICIT_LATERAL_OFFSET_AMOUNT = 1
 uint8 DIRECTION = 2
 
-# Options for shift_direction_value
+# Options for shift_direction_value (used when shift_mode = DIRECTION)
 uint8 RESET = 0
 uint8 LEFT = 1
 uint8 RIGHT = 2
 
 uint8 shift_mode
 
-# When shift_mode = RAW_VALUE (in meters)
+# When shift_mode = EXPLICIT_LATERAL_OFFSET_AMOUNT:
+# Target lateral offset [m], same convention as LateralOffset.msg topic
+# positive -> left of the reference path, negative -> right of the reference path
 float32 shift_value
 
 # When shift_mode = DIRECTION

--- a/tier4_planning_msgs/srv/SetLateralOffset.srv
+++ b/tier4_planning_msgs/srv/SetLateralOffset.srv
@@ -15,4 +15,15 @@ float32 shift_value
 # When shift_mode = DIRECTION
 uint8 shift_direction_value
 ---
+# code
+uint16 SUCCESS = 0
+uint16 ERROR_UNKNOWN = 10000
+uint16 ERROR_INVALID_MODE = 10001
+uint16 ERROR_INVALID_DIRECTION = 10002
+uint16 ERROR_EXCEEDED_LIMIT = 10003
+uint16 ERROR_SHIFT_GAP_TOO_SMALL = 10004
+uint16 ERROR_MODULES_CONFLICTING = 10005
+uint16 WARN_UNKNOWN = 20000
+uint16 WARN_EXCEEDED_LIMIT = 20001
+
 autoware_common_msgs/ResponseStatus status


### PR DESCRIPTION
## Related Links

You can see en example video in this PR.
https://github.com/autowarefoundation/autoware_universe/pull/12474 

## Description

This PR adds a new service type `SetLateralOffset.srv`.
This service is made for the `autoware_behavior_path_side_shift_module` (hereafter "side_shift module") so that the side_shift module can have a ROS 2 service input rather than a topic input.

Plus, the side_shift module can get ambiguous discrete values like `left` or `right` so that the service caller (a human is expected) don't have to specify an exact value on driving.

## How to use

First the user choose from two modes `EXPLICIT_LATERAL_OFFSET_AMOUNT` and `LATERAL_OFFSET_DIRECTION ` and set it to `shift_mode`.

- If `EXPLICIT_LATERAL_OFFSET_AMOUNT` is chosen, the side_shift module will shift the path with the length written in `shift_value`, same as publishing a `LateralOffset` topic to the module. `shift_direction_value` is not used in this mode.
- If `LATERAL_OFFSET_DIRECTION ` is chosen, the side_shift module will shift to the selected direction set in `shift_direction_value`. The shift length for a single `LEFT/RIGHT` command will be defined in the parameter file. If it is set to `RESET` the shift length will be set to 0.0 meters and the vehicle will return to the original path. `shift_value` is not used in this mode.

The response is a normal `autoware_common_msgs/ResponseStatus` but some error codes are set to get information from the side_shift module.

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code is properly formatted
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
