### PR TITLE
chore: remove DISCLAIMER from sync-file list

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -21,5 +21,4 @@
     - source: .yamllint.yaml
     - source: CODE_OF_CONDUCT.md
     - source: CONTRIBUTING.md
-    - source: DISCLAIMER.md
     - source: LICENSE


### PR DESCRIPTION
## Related Links

Follow up from https://github.com/tier4/tier4_autoware_msgs/pull/212.


## Description

In the above PR, we added Disclaimer as sync file target, but since this repository is not owned by AWF, we could remove from the list.

<!-- Describe what this PR changes. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code is properly formatted
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
